### PR TITLE
More Camo Requirement Fixes

### DIFF
--- a/src/data/requirements/camo/digital.js
+++ b/src/data/requirements/camo/digital.js
@@ -77,7 +77,7 @@ export default {
 	'Chemist Digital': {
 		weapon: 'TAQ-M',
 		level: '25',
-		challenge: 'Get 20 kills while mounted',
+		challenge: 'Get 10 double kills',
 	},
 	'Asphalt Digital': {
 		weapon: 'X13 Auto',

--- a/src/data/requirements/camo/reptile.js
+++ b/src/data/requirements/camo/reptile.js
@@ -52,7 +52,7 @@ export default {
 	'Skin and Scales': {
 		weapon: 'TAQ-M',
 		level: '17',
-		challenge: 'Get 10 double kills',
+		challenge: 'Get 5 hipfire kills',
 	},
 	'Heavy Commando': {
 		weapon: 'SO-14',

--- a/src/data/requirements/camo/woodland.js
+++ b/src/data/requirements/camo/woodland.js
@@ -92,6 +92,6 @@ export default {
 	'Forest Water': {
 		weapon: 'TAQ-M',
 		level: '10',
-		challenge: 'Get 5 hipfire kills',
+		challenge: 'Get 20 kills while mounted',
 	},
 }

--- a/src/data/requirements/weapons/battleRifles.js
+++ b/src/data/requirements/weapons/battleRifles.js
@@ -29,7 +29,7 @@ export default {
 	'SO-14': {
 		'Dune Stalker': woodland['Dune Stalker'],
 		'Reptilian': dragon['Reptilian'],
-		'Heavy Command': reptile['Heavy Commando'],
+		'Heavy Commando': reptile['Heavy Commando'],
 		'Tendrils': stripes['Tendrils'],
 		...masteryChallenges,
 	},

--- a/src/data/requirements/weapons/marksmanRifles.js
+++ b/src/data/requirements/weapons/marksmanRifles.js
@@ -63,7 +63,7 @@ export default {
 	'TAQ-M': {
 		'Dead Hive': sprayPaint['Dead Hive'],
 		'Forest Water': woodland['Forest Water'],
-		'Skin and Scales': reptile['Skin And Scales'],
+		'Skin and Scales': reptile['Skin and Scales'],
 		'Chemist Digital': digital['Chemist Digital'],
 		...masteryChallenges,
 	},


### PR DESCRIPTION
## Changelog

-Fixed incorrect `TAQ-M` camo challenges
-Fixed the `Heavy Commando` and `Skin and Scales` camos showing `TBA`

## Issue

The `2087` camo is the first camo on the row of the `Fennec 45` when it should be the last.
The issue causing this is due to the `2087` camo name, if the first character in the camo name is a number then it will automatically be first in line.