### PR TITLE
[New Feature] Add favorites feature to camouflages

### DIFF
--- a/src/components/AlertComponent.vue
+++ b/src/components/AlertComponent.vue
@@ -1,6 +1,6 @@
 <template>
 	<div :class="['alert', type]">
-		<IconComponent :name="icon || typeIcon" />
+		<IconComponent v-if="icon || typeIcon" :name="icon || typeIcon" />
 		<div class="content">
 			<slot />
 		</div>
@@ -66,12 +66,25 @@ export default {
 		}
 	}
 
-	.icon-component {
+	&.empty-state {
+		.content {
+			color: rgba(white, 0.5);
+			text-align: center;
+		}
+	}
+
+	> .icon-component {
 		margin-right: 10px;
 	}
 
 	.content {
 		line-height: 1.6;
+		width: 100%;
+
+		> .icon-component {
+			position: relative;
+			top: 3px;
+		}
 	}
 }
 </style>

--- a/src/components/CamouflageComponent.vue
+++ b/src/components/CamouflageComponent.vue
@@ -1,20 +1,31 @@
 <template>
-	<div
-		class="camouflage"
-		@click="handleToggleCompleted(camouflage)"
-		:content="requirementTooltip(camouflage)"
-		v-tippy="{ placement: 'bottom' }">
-		<div :class="['inner', this.isCompleted ? 'completed' : '']">
-			<img
-				:src="imageUrl(camouflage.name)"
-				:alt="camouflage.name"
-				onerror="javascript:this.src='/base-gradient.svg'" />
-			<IconComponent class="complete" name="check" fill="#10ac84" />
-			<IconComponent class="remove" name="times" fill="#ee5253" />
-			<span>
-				{{ camouflage.name }}
-			</span>
+	<div :class="['camouflage-wrapper', { favorite: isFavorite }]">
+		<div
+			class="camouflage"
+			@click="handleToggleCompleted(camouflage)"
+			:content="requirementTooltip(camouflage)"
+			v-tippy="{ placement: 'bottom' }">
+			<div :class="['inner', this.isCompleted ? 'completed' : '']">
+				<img
+					:src="imageUrl(camouflage.name)"
+					:alt="camouflage.name"
+					onerror="javascript:this.src='/base-gradient.svg'" />
+				<IconComponent class="complete" name="check" fill="#10ac84" />
+				<IconComponent class="remove" name="times" fill="#ee5253" />
+				<span>
+					{{ camouflage.name }}
+				</span>
+			</div>
 		</div>
+
+		<IconComponent
+			class="favorite-icon"
+			name="star"
+			:fill="isFavorite ? '#feca57' : 'gray'"
+			icon-style="solid"
+			size="25"
+			@click="toggleFavorite({ type: 'camouflages', name: camouflage.name })"
+			v-tippy="{ content: `${isFavorite ? 'Remove from' : 'Add to'} favorites` }" />
 	</div>
 </template>
 
@@ -22,6 +33,8 @@
 import { useStore } from '@/stores/store'
 import { convertToKebabCase } from '@/utils/utils'
 import { mapActions, mapState } from 'pinia'
+
+const store = useStore()
 
 export default {
 	data() {
@@ -39,11 +52,19 @@ export default {
 
 	computed: {
 		...mapState(useStore, ['camouflageRequirements']),
+
+		isFavorite() {
+			return store.isFavorite('camouflages', this.camouflage.name)
+		},
 	},
 
 	methods: {
 		convertToKebabCase,
-		...mapActions(useStore, ['toggleCamouflageCompleted', 'toggleGoldCamouflageCompleted']),
+		...mapActions(useStore, [
+			'toggleCamouflageCompleted',
+			'toggleGoldCamouflageCompleted',
+			'toggleFavorite',
+		]),
 
 		imageUrl(camouflageName) {
 			if (camouflageName === 'Gold') {
@@ -81,103 +102,128 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.camouflage {
-	user-select: none;
+.camouflage-wrapper {
+	position: relative;
 
-	.inner {
-		align-items: center;
-		background: $elevation-2-color;
-		border-radius: $border-radius;
+	&.favorite .favorite-icon {
+		opacity: 1 !important;
+	}
+
+	&:hover {
+		.favorite-icon {
+			opacity: 1;
+		}
+	}
+
+	.favorite-icon {
 		cursor: pointer;
-		display: flex;
-		height: 100%;
-		justify-content: center;
-		overflow: hidden;
-		position: relative;
+		opacity: 0;
+		position: absolute;
+		right: 0;
+		top: 0;
 		transition: $transition;
-		width: 100%;
-		flex-direction: column;
+		transform: translate(50%, -50%);
+		z-index: 2;
+	}
 
-		span {
-			padding: 10px;
-		}
+	.camouflage {
+		user-select: none;
 
-		&:hover {
-			@media (min-width: $tablet) {
-				img,
-				p {
-					opacity: 0.25;
-				}
+		.inner {
+			align-items: center;
+			background: $elevation-2-color;
+			border-radius: $border-radius;
+			cursor: pointer;
+			display: flex;
+			height: 100%;
+			justify-content: center;
+			overflow: hidden;
+			position: relative;
+			transition: $transition;
+			width: 100%;
+			flex-direction: column;
 
-				.icon-component.complete {
-					opacity: 1;
-				}
+			span {
+				padding: 10px;
 			}
-		}
 
-		&.completed {
 			&:hover {
 				@media (min-width: $tablet) {
-					.icon-component.complete {
-						opacity: 0;
+					img,
+					p {
+						opacity: 0.25;
 					}
-					.icon-component.remove {
+
+					.icon-component.complete {
 						opacity: 1;
 					}
 				}
 			}
 
-			img,
-			p {
-				opacity: 0.25;
-			}
-
-			.icon-component {
-				&.complete {
-					opacity: 1;
+			&.completed {
+				&:hover {
+					@media (min-width: $tablet) {
+						.icon-component.complete {
+							opacity: 0;
+						}
+						.icon-component.remove {
+							opacity: 1;
+						}
+					}
 				}
 
-				&.remove {
-					opacity: 0;
-				}
-			}
-		}
-
-		&.disabled {
-			cursor: not-allowed;
-
-			&:hover {
 				img,
 				p {
-					opacity: 1;
+					opacity: 0.25;
 				}
 
 				.icon-component {
-					opacity: 0;
+					&.complete {
+						opacity: 1;
+					}
+
+					&.remove {
+						opacity: 0;
+					}
 				}
 			}
-		}
 
-		.icon-component {
-			left: 50%;
-			opacity: 0;
-			position: absolute;
-			transform: translate(-50%, -50%);
-			transition: $transition;
-			top: 35%;
-			z-index: 2;
-		}
+			&.disabled {
+				cursor: not-allowed;
 
-		img {
-			height: 80px;
-			object-fit: cover;
-			position: relative;
-			width: 100%;
-			z-index: 1;
-		}
+				&:hover {
+					img,
+					p {
+						opacity: 1;
+					}
 
-		p {
-			font-size: 14px;
+					.icon-component {
+						opacity: 0;
+					}
+				}
+			}
+
+			.icon-component {
+				left: 50%;
+				opacity: 0;
+				position: absolute;
+				transform: translate(-50%, -50%);
+				transition: $transition;
+				top: 35%;
+				z-index: 2;
+			}
+
+			img {
+				height: 80px;
+				object-fit: cover;
+				position: relative;
+				width: 100%;
+				z-index: 1;
+			}
+
+			p {
+				font-size: 14px;
+			}
 		}
 	}
 }

--- a/src/components/CamouflageComponent.vue
+++ b/src/components/CamouflageComponent.vue
@@ -124,6 +124,11 @@ export default {
 		transition: $transition;
 		transform: translate(50%, -50%);
 		z-index: 2;
+
+		@media (max-width: $tablet) {
+			opacity: 1 !important;
+			transform: translate(50%, -50%) scale(1.25);
+		}
 	}
 
 	.camouflage {

--- a/src/components/CamouflagesComponent.vue
+++ b/src/components/CamouflagesComponent.vue
@@ -1,15 +1,21 @@
 <template>
 	<div>
 		<transition-group name="fade" tag="div" class="container">
-			<div v-if="favorites.length > 0" :key="'favorites'" class="category">
+			<div :key="'favorites'" class="category">
 				<h2>Favorites</h2>
 
-				<transition-group name="fade" tag="div" class="camouflages">
+				<transition-group v-if="favorites.length > 0" name="fade" tag="div" class="camouflages">
 					<CamouflageComponent
 						v-for="camouflage in favorites"
 						:key="camouflage.name"
 						:camouflage="camouflage" />
 				</transition-group>
+
+				<AlertComponent v-else type="empty-state" style="padding: 42px 15px">
+					You don't have any favorites yet. Click the
+					<IconComponent name="star" fill="#feca57" icon-style="solid" size="20" /> icon on a
+					camouflage to add it to your favorites.
+				</AlertComponent>
 			</div>
 
 			<div
@@ -44,10 +50,13 @@
 <script>
 import { mapState } from 'pinia'
 import { useStore } from '@/stores/store'
+
+import AlertComponent from '@/components/AlertComponent.vue'
 import CamouflageComponent from '@/components/CamouflageComponent.vue'
 
 export default {
 	components: {
+		AlertComponent,
 		CamouflageComponent,
 	},
 

--- a/src/components/CamouflagesComponent.vue
+++ b/src/components/CamouflagesComponent.vue
@@ -1,6 +1,17 @@
 <template>
 	<div>
 		<transition-group name="fade" tag="div" class="container">
+			<div v-if="favorites.length > 0" :key="'favorites'" class="category">
+				<h2>Favorites</h2>
+
+				<transition-group name="fade" tag="div" class="camouflages">
+					<CamouflageComponent
+						v-for="camouflage in favorites"
+						:key="camouflage.name"
+						:camouflage="camouflage" />
+				</transition-group>
+			</div>
+
 			<div
 				v-for="(category, title, index) in camouflages"
 				:key="title"
@@ -16,7 +27,10 @@
 				</h2>
 
 				<transition-group name="fade" tag="div" class="camouflages">
-					<CamouflageComponent v-for="camouflage in category" :key="camouflage.name" :camouflage="camouflage" />
+					<CamouflageComponent
+						v-for="camouflage in category"
+						:key="camouflage.name"
+						:camouflage="camouflage" />
 				</transition-group>
 			</div>
 		</transition-group>
@@ -40,6 +54,11 @@ export default {
 	props: {
 		camouflages: {
 			type: Object,
+			required: true,
+		},
+
+		favorites: {
+			type: Array,
 			required: true,
 		},
 	},

--- a/src/components/FiltersComponent.vue
+++ b/src/components/FiltersComponent.vue
@@ -115,6 +115,7 @@ export default {
 		@media (max-width: $tablet) {
 			flex-direction: column;
 			padding-top: 50px;
+			width: 100%;
 		}
 
 		.info {

--- a/src/stores/store.js
+++ b/src/stores/store.js
@@ -14,6 +14,10 @@ export const useStore = defineStore({
 	state: () => ({
 		beganGrind: null,
 		camouflageRequirements: { ...camouflageRequirements },
+		favorites: {
+			camouflages: [],
+			weapons: [],
+		},
 		filters: {},
 		weaponRequirements: { ...weaponRequirements },
 		weapons: [],
@@ -21,6 +25,8 @@ export const useStore = defineStore({
 
 	getters: {
 		categories: (state) => Array.from(new Set(state.weapons.map((weapon) => weapon.category))),
+		isFavorite: (state) => (type, name) => state.favorites[type].includes(name),
+		getFavorites: (state) => (type) => state.favorites[type],
 	},
 
 	actions: {
@@ -40,6 +46,11 @@ export const useStore = defineStore({
 					}
 				})
 			}
+		},
+
+		setFavorites({ camouflages, weapons }) {
+			this.favorites.camouflages = camouflages || []
+			this.favorites.weapons = weapons || []
 		},
 
 		setFilters(filters) {
@@ -63,11 +74,12 @@ export const useStore = defineStore({
 				return
 			}
 
-			const { weapons, filters, beganGrind } = JSON.parse(storage)
+			const { weapons, filters, beganGrind, favorites } = JSON.parse(storage)
 
 			if (weapons) this.setWeapons(weapons)
 			if (filters) this.setFilters(filters)
 			if (beganGrind) this.beganGrind = beganGrind
+			if (favorites) this.setFavorites(favorites)
 		},
 
 		storeProgress() {
@@ -77,6 +89,7 @@ export const useStore = defineStore({
 					weapons: this.weapons,
 					filters: this.filters,
 					beganGrind: this.beganGrind || new Date(),
+					favorites: this.favorites,
 				})
 			)
 		},
@@ -90,6 +103,18 @@ export const useStore = defineStore({
 				type: 'success',
 				title: 'Progress successfully reset!',
 			})
+		},
+
+		toggleFavorite({ type, name }) {
+			const index = this.favorites[type].findIndex((favorite) => favorite === name)
+
+			if (index === -1) {
+				this.favorites[type].push(name)
+			} else {
+				this.favorites[type].splice(index, 1)
+			}
+
+			this.storeProgress()
 		},
 
 		toggleCamouflageCompleted(weaponName, camouflage, current) {

--- a/src/utils/unicons.js
+++ b/src/utils/unicons.js
@@ -24,6 +24,7 @@ import {
 	uniMobileAndroid,
 	uniQuestionCircle,
 	uniSave,
+	uniStarSolid,
 	uniTimes,
 	uniTrash,
 } from 'vue-unicons/dist/icons'
@@ -52,6 +53,7 @@ export default [
 	uniMobileAndroid,
 	uniQuestionCircle,
 	uniSave,
+	uniStarSolid,
 	uniTimes,
 	uniTrash,
 ]

--- a/src/views/CamouflagesView.vue
+++ b/src/views/CamouflagesView.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="container">
-		<CamouflagesComponent :camouflages="camouflages" />
+		<CamouflagesComponent :camouflages="camouflages" :favorites="favorites" />
 		<ProgressComponent />
 	</div>
 </template>
@@ -13,6 +13,8 @@ import camouflages from '../data/camouflages'
 
 import CamouflagesComponent from '@/components/CamouflagesComponent.vue'
 import ProgressComponent from '@/components/ProgressComponent.vue'
+
+const store = useStore()
 
 export default {
 	components: {
@@ -34,6 +36,11 @@ export default {
 			})
 
 			return groupBy(camouflages, (camouflage) => camouflage.category)
+		},
+
+		favorites() {
+			const favorites = store.getFavorites('camouflages')
+			return camouflages.filter((camouflage) => favorites.includes(camouflage.name))
 		},
 	},
 }


### PR DESCRIPTION
Adds favorites to the camouflages view, making it easer to track specific camouflages.

- Adds a new "Favorites" category always at the top
- Adds a star icon on each favorited camouflage
- Saved between sessions, as all other data

Test it by opening the deployment from Vercel. 

Thoughts, @sol3uk? 😄 

![image](https://user-images.githubusercontent.com/10532336/201474542-2f455eba-a457-4cb9-a9a0-fd1615d2a2af.png)
