### PR TITLE
Fixes #12 - 2087 Reordering

### DIFF
--- a/src/data/defaults/progress/subMachineGuns.js
+++ b/src/data/defaults/progress/subMachineGuns.js
@@ -52,6 +52,6 @@ export default {
 		'Motley': false,
 		'Eclipse': false,
 		'Feral Beast': false,
-		'2087': false,
+		'2087 ': false,
 	},
 }

--- a/src/data/requirements/camouflages/classic.js
+++ b/src/data/requirements/camouflages/classic.js
@@ -24,7 +24,7 @@ export default {
 		level: '23',
 		challenge: 'Get 25 one-shot kills',
 	},
-	'2087': {
+	'2087 ': {
 		weapon: 'Fennec 45',
 		level: '26',
 		challenge: 'Get 10 double kills',

--- a/src/data/requirements/weapons/subMachineGuns.js
+++ b/src/data/requirements/weapons/subMachineGuns.js
@@ -80,7 +80,7 @@ export default {
 		'Motley': geometric['Motley'],
 		'Eclipse': tiger['Eclipse'],
 		'Feral Beast': tiger['Feral Beast'],
-		'2087': classic['2087'],
+		'2087 ': classic['2087 '],
 		...masteryChallenges,
 	},
 }


### PR DESCRIPTION
I know this isn't a great fix, it's more of a hack, the only other way I can think about working around this, would require rewriting a LOT of code to handle the names of all camos as arrays or as nested objects for just a fix to this 1 camo.
Thought I'd put it forward as a quick fix until we can fix it properly in the long run.