### PR TITLE
Reorder camos to be same as in game

### DIFF
--- a/src/data/camouflages.js
+++ b/src/data/camouflages.js
@@ -14,18 +14,18 @@ import tiger from './camouflages/tiger'
 import woodland from './camouflages/woodland'
 
 export default [
-	...classic,
-	...cliffside,
+	...sprayPaint,
+	...woodland,
 	...digital,
 	...dragon,
-	...foliage,
-	...fun,
 	...geometric,
-	...reptile,
+	...fun,
+	...foliage,
 	...skulls,
-	...solidColors,
-	...sprayPaint,
-	...stripes,
 	...tiger,
-	...woodland,
+	...stripes,
+	...reptile,
+	...solidColors,
+	...classic,
+	...cliffside,
 ]


### PR DESCRIPTION
We could add an "Order By" functionality if requested by users, but I think for now we should keep it same as in game, it makes it easier to go through the camos in game and check them off alongside the app.