### PR TITLE
[Feature] Add functionality to toggle between Grid and List layouts for camouflages

### DIFF
--- a/src/components/CamouflageComponent.vue
+++ b/src/components/CamouflageComponent.vue
@@ -1,7 +1,7 @@
 <template>
 	<div :class="['camouflage-wrapper', { favorite: isFavorite }]">
 		<div
-			class="camouflage"
+			:class="['camouflage', `camouflage-layout-${layout}`]"
 			@click="handleToggleCompleted(camouflage)"
 			:content="requirementTooltip(camouflage)"
 			v-tippy="{ placement: 'bottom' }">
@@ -10,11 +10,12 @@
 					:src="imageUrl(camouflage.name)"
 					:alt="camouflage.name"
 					onerror="javascript:this.src='/base-gradient.svg'" />
-				<IconComponent class="complete" name="check" fill="#10ac84" />
-				<IconComponent class="remove" name="times" fill="#ee5253" />
-				<span>
-					{{ camouflage.name }}
-				</span>
+				<IconComponent class="complete" name="check" fill="#10ac84" size="30" />
+				<IconComponent class="remove" name="times" fill="#ee5253" size="30" />
+				<div class="info">
+					<span class="name">{{ camouflage.name }}</span>
+					<span class="requirement">{{ requirementTooltip(camouflage) }}</span>
+				</div>
 			</div>
 		</div>
 
@@ -51,7 +52,11 @@ export default {
 	},
 
 	computed: {
-		...mapState(useStore, ['camouflageRequirements']),
+		...mapState(useStore, ['camouflageRequirements', 'preferences']),
+
+		layout() {
+			return this.preferences.layout
+		},
 
 		isFavorite() {
 			return store.isFavorite('camouflages', this.camouflage.name)
@@ -134,6 +139,83 @@ export default {
 	.camouflage {
 		user-select: none;
 
+		&.camouflage-layout-grid > .inner {
+			flex-direction: column;
+			justify-content: center;
+
+			&.completed > .info {
+				opacity: 0.5;
+			}
+
+			img {
+				height: 80px;
+				object-fit: cover;
+				position: relative;
+				width: 100%;
+				z-index: 1;
+			}
+
+			.icon-component {
+				left: 50%;
+				opacity: 0;
+				position: absolute;
+				transform: translate(-50%, -50%);
+				transition: $transition;
+				top: 35%;
+				z-index: 2;
+			}
+
+			.info {
+				padding: 8px;
+
+				.name {
+					font-size: 14px;
+				}
+			}
+		}
+
+		&.camouflage-layout-list > .inner {
+			$image-size: 100px;
+			background: $elevation-1-color;
+			flex-direction: row;
+
+			&.completed > .info {
+				opacity: 0.5;
+			}
+
+			img {
+				height: $image-size;
+				position: relative;
+				width: $image-size;
+				z-index: 1;
+			}
+
+			.icon-component {
+				left: calc($image-size / 2);
+				opacity: 0;
+				position: absolute;
+				transform: translate(-50%, -50%);
+				transition: $transition;
+				top: 50%;
+				z-index: 2;
+			}
+
+			.info {
+				padding: 0 20px;
+				text-align: left;
+
+				.name {
+					font-weight: 500;
+				}
+
+				.requirement {
+					display: block;
+					font-size: 14px;
+					margin-top: 15px;
+				}
+			}
+		}
+
 		.inner {
 			align-items: center;
 			background: $elevation-2-color;
@@ -141,16 +223,10 @@ export default {
 			cursor: pointer;
 			display: flex;
 			height: 100%;
-			justify-content: center;
 			overflow: hidden;
 			position: relative;
 			transition: $transition;
 			width: 100%;
-			flex-direction: column;
-
-			span {
-				padding: 10px;
-			}
 
 			&:hover {
 				@media (min-width: $tablet) {
@@ -208,22 +284,12 @@ export default {
 				}
 			}
 
-			.icon-component {
-				left: 50%;
-				opacity: 0;
-				position: absolute;
-				transform: translate(-50%, -50%);
-				transition: $transition;
-				top: 35%;
-				z-index: 2;
-			}
+			.info {
+				transition: opacity $transition;
 
-			img {
-				height: 80px;
-				object-fit: cover;
-				position: relative;
-				width: 100%;
-				z-index: 1;
+				.requirement {
+					display: none;
+				}
 			}
 
 			p {

--- a/src/components/CamouflageComponent.vue
+++ b/src/components/CamouflageComponent.vue
@@ -211,7 +211,8 @@ export default {
 				.requirement {
 					display: block;
 					font-size: 14px;
-					margin-top: 15px;
+					line-height: 1.5;
+					margin-top: 10px;
 				}
 			}
 		}

--- a/src/components/CamouflagesComponent.vue
+++ b/src/components/CamouflagesComponent.vue
@@ -147,9 +147,9 @@ export default {
 		}
 
 		.camouflages {
+			display: grid;
+			gap: 30px;
 			&.layout-grid {
-				display: grid;
-				gap: 30px;
 				grid-template-columns: repeat(5, 1fr);
 
 				@media (max-width: $tablet) {
@@ -158,9 +158,11 @@ export default {
 			}
 
 			&.layout-list {
-				display: flex;
-				flex-direction: column;
-				gap: 30px;
+				grid-template-columns: repeat(2, 1fr);
+
+				@media (max-width: $tablet) {
+					grid-template-columns: 1fr;
+				}
 			}
 		}
 	}

--- a/src/components/CamouflagesComponent.vue
+++ b/src/components/CamouflagesComponent.vue
@@ -4,7 +4,11 @@
 			<div :key="'favorites'" class="category">
 				<h2>Favorites</h2>
 
-				<transition-group v-if="favorites.length > 0" name="fade" tag="div" class="camouflages">
+				<transition-group
+					v-if="favorites.length > 0"
+					name="fade"
+					tag="div"
+					:class="['camouflages', `layout-${layout}`]">
 					<CamouflageComponent
 						v-for="camouflage in favorites"
 						:key="camouflage.name"
@@ -32,7 +36,7 @@
 					</span>
 				</h2>
 
-				<transition-group name="fade" tag="div" class="camouflages">
+				<transition-group name="fade" tag="div" :class="['camouflages', `layout-${layout}`]">
 					<CamouflageComponent
 						v-for="camouflage in category"
 						:key="camouflage.name"
@@ -73,7 +77,11 @@ export default {
 	},
 
 	computed: {
-		...mapState(useStore, ['weapons']),
+		...mapState(useStore, ['weapons', 'preferences']),
+
+		layout() {
+			return this.preferences.layout
+		},
 	},
 
 	methods: {
@@ -139,13 +147,20 @@ export default {
 		}
 
 		.camouflages {
-			display: grid;
-			gap: 30px;
-			grid-template-columns: repeat(5, 1fr);
-			width: 100%;
+			&.layout-grid {
+				display: grid;
+				gap: 30px;
+				grid-template-columns: repeat(5, 1fr);
 
-			@media (max-width: $tablet) {
-				grid-template-columns: 1fr;
+				@media (max-width: $tablet) {
+					grid-template-columns: 1fr;
+				}
+			}
+
+			&.layout-list {
+				display: flex;
+				flex-direction: column;
+				gap: 30px;
 			}
 		}
 	}

--- a/src/components/FiltersComponent.vue
+++ b/src/components/FiltersComponent.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="filters-container">
+	<div class="filters-component">
 		<button @click="toggleFilters()" id="toggle-filter-button">
 			<IconComponent v-if="filters.hideFilters" name="filter" />
 			<IconComponent v-else name="filter-slash" />
@@ -97,7 +97,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.filters-container {
+.filters-component {
 	align-items: center;
 	display: flex;
 	margin: 50px 0;

--- a/src/components/FiltersComponent.vue
+++ b/src/components/FiltersComponent.vue
@@ -1,11 +1,5 @@
 <template>
 	<div class="filters-component">
-		<button @click="toggleFilters()" id="toggle-filter-button">
-			<IconComponent v-if="filters.hideFilters" name="filter" />
-			<IconComponent v-else name="filter-slash" />
-			<span>{{ filters.hideFilters ? 'Show' : 'Hide' }} filters</span>
-		</button>
-
 		<transition name="fade">
 			<div v-if="!filters.hideFilters" class="filters">
 				<FilterComponent
@@ -36,19 +30,14 @@
 			</div>
 		</transition>
 
-		<div id="toggle-filter-icon">
-			<IconComponent
-				@click="toggleFilters()"
-				v-if="filters.hideFilters"
-				name="filter"
-				class="show-icon"
-				v-tippy="{ content: 'Show filters' }" />
-			<IconComponent
-				@click="toggleFilters()"
-				v-else
-				name="filter-slash"
-				v-tippy="{ content: 'Hide filters' }" />
-		</div>
+		<button
+			@click="toggleFilters()"
+			id="toggle-filter-button"
+			v-tippy="{ content: `${filters.hideFilters ? 'Show' : 'Hide'} filters` }">
+			<IconComponent v-if="filters.hideFilters" name="filter" />
+			<IconComponent v-else name="filter-slash" />
+			<span>{{ filters.hideFilters ? 'Show' : 'Hide' }} filters</span>
+		</button>
 	</div>
 </template>
 
@@ -103,7 +92,7 @@ export default {
 	margin: 50px 0;
 
 	@media (max-width: $tablet) {
-		flex-direction: column;
+		flex-direction: column-reverse;
 		margin-top: 0;
 	}
 
@@ -178,47 +167,38 @@ export default {
 
 button#toggle-filter-button {
 	align-items: center;
-	background: $elevation-3-color;
-	color: white;
+	background: $elevation-2-color;
+	border: 2px solid $elevation-4-color;
+	border-radius: $border-radius;
+	color: rgba($text-color, 0.75);
 	display: inline-flex;
-	font-size: 18px;
-	padding: 16px;
+	font-size: 16px;
+	justify-content: center;
+	padding: 15px;
 	width: 100%;
 
 	@media (min-width: $tablet) {
-		display: none;
+		margin-left: auto;
+		padding: 3px 5px;
+		width: auto;
 	}
 
 	.icon-component {
-		margin-right: 15px;
-		opacity: 0.3;
+		margin-right: 5px;
+		opacity: 0.75;
+		width: 18px;
 
-		&.hide-icon {
-			position: relative;
-			top: -7px;
+		@media (min-width: $tablet) {
+			margin-right: 0;
 		}
 	}
-}
 
-div#toggle-filter-icon {
-	cursor: pointer;
-	display: none;
-	margin-left: auto;
-	opacity: 0.5;
-	transition: $transition;
-
-	@media (min-width: $tablet) {
+	span {
 		display: block;
-	}
 
-	&:hover {
-		opacity: 0.75;
-	}
-
-	.show-icon {
-		left: 1px;
-		position: relative;
-		top: 3px;
+		@media (min-width: $tablet) {
+			display: none;
+		}
 	}
 }
 </style>

--- a/src/components/LayoutToggleComponent.vue
+++ b/src/components/LayoutToggleComponent.vue
@@ -59,6 +59,16 @@ export default {
 		background: $elevation-3-color;
 	}
 
+	@media (max-width: $tablet) {
+		margin: 20px 0 25px;
+		padding: 15px 0;
+		width: 100%;
+
+		span {
+			font-size: 16px !important;
+		}
+	}
+
 	.icon-component {
 		margin-right: 5px;
 		opacity: 0.75;

--- a/src/components/LayoutToggleComponent.vue
+++ b/src/components/LayoutToggleComponent.vue
@@ -1,9 +1,9 @@
 <template>
-	<div class="layout-toggle" @click="toggleLayout()" v-tippy="{ content: 'Layout' }">
+	<button class="layout-toggle" @click="toggleLayout()" v-tippy="{ content: 'Toggle layout' }">
 		<IconComponent v-if="layout === 'grid'" name="apps" iconStyle="solid" size="18" />
 		<IconComponent v-else name="list-ul" size="18" />
 		<span>{{ layoutLabel }}</span>
-	</div>
+	</button>
 </template>
 
 <script>
@@ -60,7 +60,7 @@ export default {
 	}
 
 	@media (max-width: $tablet) {
-		margin: 20px 0 25px;
+		margin: 0 0 25px;
 		padding: 15px 0;
 		width: 100%;
 

--- a/src/components/LayoutToggleComponent.vue
+++ b/src/components/LayoutToggleComponent.vue
@@ -1,0 +1,72 @@
+<template>
+	<div class="layout-toggle" @click="toggleLayout()" v-tippy="{ content: 'Layout' }">
+		<IconComponent v-if="layout === 'grid'" name="apps" iconStyle="solid" size="18" />
+		<IconComponent v-else name="list-ul" size="18" />
+		<span>{{ layoutLabel }}</span>
+	</div>
+</template>
+
+<script>
+import { mapState, mapActions } from 'pinia'
+import { useStore } from '@/stores/store'
+
+export default {
+	computed: {
+		...mapState(useStore, ['preferences']),
+
+		layout() {
+			return this.preferences.layout
+		},
+
+		layoutLabel() {
+			return this.layout === 'grid' ? 'Grid' : 'List'
+		},
+	},
+
+	methods: {
+		...mapActions(useStore, ['setPreferences', 'storeProgress']),
+
+		toggleLayout() {
+			const preferences = JSON.parse(JSON.stringify(this.preferences))
+			preferences.layout = this.layout === 'grid' ? 'list' : 'grid'
+			this.updatePreferences(preferences)
+		},
+
+		updatePreferences(preferences) {
+			this.setPreferences(preferences)
+			this.storeProgress()
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.layout-toggle {
+	align-items: center;
+	background: $elevation-2-color;
+	border: 2px solid $elevation-4-color;
+	border-radius: $border-radius;
+	color: rgba($text-color, 0.75);
+	cursor: pointer;
+	display: inline-flex;
+	justify-content: center;
+	padding: 5px 0;
+	transition: $transition;
+	user-select: none;
+	width: 75px;
+
+	&:hover {
+		background: $elevation-3-color;
+	}
+
+	.icon-component {
+		margin-right: 5px;
+		opacity: 0.75;
+		width: 18px;
+	}
+
+	span {
+		font-size: 14px;
+	}
+}
+</style>

--- a/src/data/defaults/preferences.js
+++ b/src/data/defaults/preferences.js
@@ -1,0 +1,3 @@
+export default {
+	layout: 'grid',
+}

--- a/src/stores/store.js
+++ b/src/stores/store.js
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia'
 import { filterObject } from '../utils/utils'
 import defaultWeapons from '../data/weapons'
 import defaultFilters from '../data/defaults/filters'
+import defaultPreferences from '../data/defaults/preferences'
 import weaponRequirements from '../data/weaponRequirements'
 import camouflageRequirements from '../data/camouflageRequirements'
 
@@ -21,6 +22,9 @@ export const useStore = defineStore({
 		filters: {},
 		weaponRequirements: { ...weaponRequirements },
 		weapons: [],
+		preferences: {
+			layout: 'grid',
+		},
 	}),
 
 	getters: {
@@ -66,6 +70,18 @@ export const useStore = defineStore({
 			}
 		},
 
+		setPreferences(preferences) {
+			this.preferences = JSON.parse(JSON.stringify(defaultPreferences))
+
+			if (preferences) {
+				Object.keys(preferences).forEach((key) => {
+					if (key in defaultPreferences) {
+						this.preferences[key] = preferences[key]
+					}
+				})
+			}
+		},
+
 		getStoredProgress() {
 			const storage = localStorage.getItem(token)
 
@@ -75,12 +91,13 @@ export const useStore = defineStore({
 				return
 			}
 
-			const { weapons, filters, beganGrind, favorites } = JSON.parse(storage)
+			const { weapons, filters, beganGrind, favorites, preferences } = JSON.parse(storage)
 
 			if (weapons) this.setWeapons(weapons)
 			if (filters) this.setFilters(filters)
 			if (beganGrind) this.beganGrind = beganGrind
 			if (favorites) this.setFavorites(favorites)
+			if (preferences) this.setPreferences(preferences)
 		},
 
 		storeProgress() {
@@ -91,6 +108,7 @@ export const useStore = defineStore({
 					filters: this.filters,
 					beganGrind: this.beganGrind || new Date(),
 					favorites: this.favorites,
+					preferences: this.preferences,
 				})
 			)
 		},

--- a/src/utils/unicons.js
+++ b/src/utils/unicons.js
@@ -2,6 +2,7 @@
 
 import {
 	uniAngleDown,
+	uniAppsSolid,
 	uniArrowDown,
 	uniArrowLeft,
 	uniArrowRight,
@@ -21,6 +22,7 @@ import {
 	uniFilterSlash,
 	uniImageSlash,
 	uniInfoCircle,
+	uniListUl,
 	uniMobileAndroid,
 	uniQuestionCircle,
 	uniSave,
@@ -31,6 +33,7 @@ import {
 
 export default [
 	uniAngleDown,
+	uniAppsSolid,
 	uniArrowDown,
 	uniArrowLeft,
 	uniArrowRight,
@@ -50,6 +53,7 @@ export default [
 	uniFilterSlash,
 	uniImageSlash,
 	uniInfoCircle,
+	uniListUl,
 	uniMobileAndroid,
 	uniQuestionCircle,
 	uniSave,

--- a/src/views/CamouflagesView.vue
+++ b/src/views/CamouflagesView.vue
@@ -115,7 +115,8 @@ h2 {
 		flex-direction: column;
 
 		::v-deep .filters-component {
-			margin: 0;
+			margin-bottom: 20px;
+			margin-right: 0;
 			width: 100%;
 		}
 	}
@@ -123,6 +124,6 @@ h2 {
 
 ::v-deep .filters-component {
 	flex-grow: 1;
-	margin-right: 25px;
+	margin-right: 15px;
 }
 </style>

--- a/src/views/CamouflagesView.vue
+++ b/src/views/CamouflagesView.vue
@@ -1,6 +1,9 @@
 <template>
 	<div class="container">
-		<FiltersComponent :options="filterOptions" />
+		<div style="display: flex; align-items: center">
+			<FiltersComponent :options="filterOptions" />
+			<LayoutToggleComponent />
+		</div>
 		<CamouflagesComponent :camouflages="filteredCamouflages" :favorites="favorites" />
 		<ProgressComponent />
 	</div>
@@ -14,6 +17,7 @@ import camouflages from '../data/camouflages'
 
 import CamouflagesComponent from '@/components/CamouflagesComponent.vue'
 import FiltersComponent from '@/components/FiltersComponent.vue'
+import LayoutToggleComponent from '@/components/LayoutToggleComponent.vue'
 import ProgressComponent from '@/components/ProgressComponent.vue'
 
 const store = useStore()
@@ -22,6 +26,7 @@ export default {
 	components: {
 		CamouflagesComponent,
 		FiltersComponent,
+		LayoutToggleComponent,
 		ProgressComponent,
 	},
 
@@ -99,5 +104,10 @@ h1 {
 h2 {
 	margin: 30px auto 0;
 	max-width: 450px;
+}
+
+::v-deep .filters-component {
+	flex-grow: 1;
+	margin-right: 25px;
 }
 </style>

--- a/src/views/CamouflagesView.vue
+++ b/src/views/CamouflagesView.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="container">
-		<div style="display: flex; align-items: center">
+		<div class="filter-container">
 			<FiltersComponent :options="filterOptions" />
 			<LayoutToggleComponent />
 		</div>
@@ -104,6 +104,21 @@ h1 {
 h2 {
 	margin: 30px auto 0;
 	max-width: 450px;
+}
+
+.filter-container {
+	align-items: center;
+	display: flex;
+	width: 100%;
+
+	@media (max-width: $tablet) {
+		flex-direction: column;
+
+		::v-deep .filters-component {
+			margin: 0;
+			width: 100%;
+		}
+	}
 }
 
 ::v-deep .filters-component {


### PR DESCRIPTION
Adds functionality to toggle between Grid and List layouts for camouflages. Only works for the camouflages view for now, need to think about how it could be presented in the weapons view (if it's at all possible without being too cluttered).

- Fixes #19.

Thoughts, @sol3uk? 😄 