### PR TITLE
Season 1 Camo Fixes

### DIFF
--- a/src/data/defaults/progress/subMachineGuns.js
+++ b/src/data/defaults/progress/subMachineGuns.js
@@ -52,7 +52,7 @@ export default {
 		'Motley': false,
 		'Eclipse': false,
 		'Feral Beast': false,
-		'2087': false,
+		'80s Fever': false,
 	},
 
 	'BAS-P': {

--- a/src/data/requirements/camouflages/classic.js
+++ b/src/data/requirements/camouflages/classic.js
@@ -24,7 +24,7 @@ export default {
 		level: '23',
 		challenge: 'Get 25 one-shot kills',
 	},
-	'2087': {
+	'80s Fever': {
 		weapon: 'Fennec 45',
 		level: '26',
 		challenge: 'Get 10 double kills',

--- a/src/data/requirements/weapons/launchers.js
+++ b/src/data/requirements/weapons/launchers.js
@@ -4,28 +4,28 @@ export default {
 	'PILA': {
 		'Dead Leaves': woodland['Dead Leaves'],
 		'Gold': 'Get 2 kills without dying 5 times',
-		'Platinum': 'Destroy 15 streaks',
+		'Platinum': 'Destroy 15 enemy streaks, equipment, or vehicles',
 		'Polyatomic': 'Get 15 double kills',
 	},
 
 	'STRELA-P': {
 		'Deep Jungle': foliage['Deep Jungle'],
 		'Gold': 'Get 2 kills without dying 5 times',
-		'Platinum': 'Destroy 25 streaks',
+		'Platinum': 'Destroy 25 enemy streaks, equipment, or vehicles',
 		'Polyatomic': 'Get 15 double kills',
 	},
 
 	'JOKR': {
 		'Azure Fray': woodland['Azure Fray'],
 		'Gold': 'Get 2 kills without dying 10 times',
-		'Platinum': 'Destroy 10 streaks',
+		'Platinum': 'Destroy 10 enemy streaks, equipment, or vehicles',
 		'Polyatomic': 'Get 15 double kills',
 	},
 
 	'RPG-7': {
 		'Jungle Digital': digital['Jungle Digital (RPG)'],
 		'Gold': 'Get 2 kills without dying 5 times',
-		'Platinum': 'Destroy 10 streaks',
+		'Platinum': 'Destroy 10 enemy streaks, equipment, or vehicles',
 		'Polyatomic': 'Get 15 double kills',
 	},
 }

--- a/src/data/requirements/weapons/sniperRifles.js
+++ b/src/data/requirements/weapons/sniperRifles.js
@@ -41,6 +41,8 @@ export default {
 		'Leafless': foliage['Leafless'],
 		'Teal Tiger': tiger['Teal Tiger'],
 		...masteryChallenges,
+		'Platinum': 'Get 25 longshot kills',
+		'Polyatomic': 'Get 25 headshot kills',
 	},
 
 	'SP-X 80': {
@@ -49,6 +51,8 @@ export default {
 		'Aspen': foliage['Aspen'],
 		'Lichyard': skulls['Lichyard'],
 		...masteryChallenges,
+		'Platinum': 'Get 25 longshot kills',
+		'Polyatomic': 'Get 25 headshot kills',
 	},
 	
 	'Victus XMR': {
@@ -57,5 +61,7 @@ export default {
 		'Tangographical': woodland['Tangographical'],
 		'Coral Reef': fun['Coral Reef'],
 		...masteryChallenges,
+		'Platinum': 'Get 25 longshot kills',
+		'Polyatomic': 'Get 25 headshot kills',
 	},
 }

--- a/src/data/requirements/weapons/subMachineGuns.js
+++ b/src/data/requirements/weapons/subMachineGuns.js
@@ -81,7 +81,7 @@ export default {
 		'Motley': geometric['Motley'],
 		'Eclipse': tiger['Eclipse'],
 		'Feral Beast': tiger['Feral Beast'],
-		'2087': classic['2087'],
+		'80s Fever': classic['80s Fever'],
 		...masteryChallenges,
 	},
 


### PR DESCRIPTION
## Changelog

-Changed Fennec 45 camo `2087` to `80s Fever` to reflect the in-game change
-Fixed LA-B 330, SP-X 80, and the Victus XMR, Platinum and Polyatomic camo challenge
-Included the full Platinum camo challenge for Launchers