### PR TITLE
fix: use locale on category filter for camos

### DIFF
--- a/src/components/FilterComponent.vue
+++ b/src/components/FilterComponent.vue
@@ -10,7 +10,7 @@
 					@change="$emit('change')">
 					<option value="">{{ $t('general.all') }}</option>
 					<option v-for="(option, index) in filter.options" :key="index" :value="option">
-						{{ $t('weapon_categories.' + option) }}
+						{{ $t((filter.key === 'weaponCategory' ? 'weapon_categories.' : 'camouflage_categories.') + option) }}
 					</option>
 				</select>
 				<IconComponent name="angle-down" />


### PR DESCRIPTION
Labels for the category select filter are not being properly displayed on /camouflages, its pointing to the wrong locale