### PR TITLE
Feature: Add mastery camos overall progress

### DIFF
--- a/src/components/FiltersComponent.vue
+++ b/src/components/FiltersComponent.vue
@@ -81,7 +81,7 @@ export default {
 .filters-component {
 	align-items: center;
 	display: flex;
-	margin: 50px 0;
+	margin: 25px 0;
 
 	@media (max-width: $tablet) {
 		flex-direction: column-reverse;

--- a/src/components/OverallProgressComponent.vue
+++ b/src/components/OverallProgressComponent.vue
@@ -1,0 +1,62 @@
+<template>
+	<div class="overall-progress-component">
+		<div class="counter" v-for="(counter, name) in options" :key="name">
+			<img
+				:src="`https://emilcarlsson.se/orion/camouflages/${name.toLowerCase()}.png`"
+				:alt="name"
+				onerror="javascript:this.src='/base-gradient.svg'" />
+			<span>{{ name }} {{ $t("general.unlocked") }} {{ counter }}/{{ totalWeapons }}</span>
+		</div>
+	</div>
+</template>
+
+<script>
+export default {
+	props: {
+		options: {
+			type: Object,
+			required: true,
+		},
+
+		totalWeapons: {
+			type: Number,
+			required: true,
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.overall-progress-component {
+	align-items: center;
+	display: flex;
+	margin: 0 0 25px;
+	border: 2px solid $elevation-4-color;
+	background: $elevation-2-color;
+	padding: 10px;
+	justify-content: center;
+	border-radius: $border-radius;
+
+	.counter {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+
+		img {
+			height: 100%;
+			object-fit: cover;
+			position: relative;
+			width: 25px;
+			z-index: 1;
+			border-radius: $border-radius;
+			margin: 0 5px 0 15px;
+		}
+	}
+
+	@media (max-width: $tablet) {
+		flex-direction: column;
+		margin-top: 0;
+		gap: 5px;
+	}
+}
+</style>

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -30,7 +30,8 @@
 		"show": "Show",
 		"support_notice_link": "buying me a beer",
 		"support_notice": "If you like this tracker, show your appreciation by {link} 🍺",
-		"weapon": "Weapon | Weapons"
+		"weapon": "Weapon | Weapons",
+		"unlocked": "unlocked"
 	},
 	"filters": {
 		"hide_completed": "Hide completed",

--- a/src/i18n/locales/es-CO.json
+++ b/src/i18n/locales/es-CO.json
@@ -30,7 +30,8 @@
 		"show": "Ver",
 		"support_notice_link": "comprándome una cerveza",
 		"support_notice": "Si te gusta el tracker, muestra tu aprecio {link} 🍺",
-		"weapon": "Arma | Armas"
+		"weapon": "Arma | Armas",
+		"unlocked": "desbloqueados"
 	},
 	"filters": {
 		"hide_completed": "Ocultar completados",

--- a/src/i18n/locales/sv-SE.json
+++ b/src/i18n/locales/sv-SE.json
@@ -30,7 +30,8 @@
 		"show": "Visa",
 		"support_notice_link": "köpa en öl till mig",
 		"support_notice": "Om du gillar den här hemsidan, visa din uppskattning genom att {link} 🍺",
-		"weapon": "Vapen | Vapen"
+		"weapon": "Vapen | Vapen",
+		"unlocked": "unlocked"
 	},
 	"filters": {
 		"hide_completed": "Dölj avklarade",

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -25,6 +25,8 @@
 			</div>
 		</div>
 
+		<OverallProgressComponent :options="overallProgress" :totalWeapons="this.weapons.length" />
+
 		<WeaponsComponent :weapons="filteredWeapons" :favorites="favorites" />
 
 		<ProgressComponent
@@ -62,6 +64,7 @@ import { useStore } from '@/stores/store'
 import { groupBy, daysBetweenDates, roundToTwoDecimals } from '@/utils/utils'
 
 import FiltersComponent from '@/components/FiltersComponent.vue'
+import OverallProgressComponent from '@/components/OverallProgressComponent.vue'
 import WeaponsComponent from '@/components/WeaponsComponent.vue'
 import ProgressComponent from '@/components/ProgressComponent.vue'
 import LayoutToggleComponent from '@/components/LayoutToggleComponent.vue'
@@ -70,6 +73,7 @@ import FavoritesToggleComponent from '@/components/FavoritesToggleComponent.vue'
 export default {
 	components: {
 		FiltersComponent,
+		OverallProgressComponent,
 		WeaponsComponent,
 		ProgressComponent,
 		LayoutToggleComponent,
@@ -186,6 +190,14 @@ export default {
 			}, 0)
 
 			return roundToTwoDecimals((totalCamouflagesCompleted / requiredCamouflages) * 100)
+		},
+
+		overallProgress() {
+			return {
+				Gold: this.weapons.filter((weapon) => weapon.progress.Gold).length,
+				Platinum: this.weapons.filter((weapon) => weapon.progress.Platinum).length,
+				Polyatomic: this.weapons.filter((weapon) => weapon.progress.Polyatomic).length,
+			}
 		},
 	},
 }


### PR DESCRIPTION
I thought as a cool addition to your camo tracker, an overall counter of the mastery camos would be really useful.

![image](https://user-images.githubusercontent.com/13381648/208354126-f1941ff5-11ca-4bf2-b846-ee51a79edda6.png)

Feel free to reject this if you don't like it. Or if you want me to make any changes, let me know :D