### PR TITLE
fix incorrect kv broadside camo

### DIFF
--- a/src/data/defaults/progress/shotguns.js
+++ b/src/data/defaults/progress/shotguns.js
@@ -30,7 +30,7 @@ export default {
 	'KV Broadside': {
 		'Unplumbed': false,
 		'Conflagration': false,
-		'Ethereal Rampage': false,
+		'Navy': false,
 		'Riots Nest': false,
 	},
 }

--- a/src/data/requirements/camouflages/tiger.js
+++ b/src/data/requirements/camouflages/tiger.js
@@ -127,7 +127,7 @@ export default {
 			type: 'double',
 		},
 	},
-	'Ethereal Rampage': {
+	'Navy': {
 		weapon: 'KV Broadside',
 		level: '15',
 		challenge: {

--- a/src/data/requirements/weapons/shotguns.js
+++ b/src/data/requirements/weapons/shotguns.js
@@ -64,7 +64,7 @@ export default {
 	'KV Broadside': {
 		'Unplumbed': solidColors['Unplumbed'],
 		'Conflagration': digital['Conflagration'],
-		'Ethereal Rampage': tiger['Ethereal Rampage'],
+		'Navy': solidColors['Navy'],
 		'Riots Nest': fun['Riots Nest'],
 		...masteryChallenges,
 		'Platinum': {


### PR DESCRIPTION
Ethereal Rampage doesn't seem to be a camo that's in the game, nor is it found in the Tiger category
![image](https://user-images.githubusercontent.com/96878261/226432956-bf6fdd0f-38c8-4129-bde1-dceca663efa5.png)
