### PR TITLE
Fix Bryson 800 one shot kills requirement

### DIFF
--- a/src/data/requirements/camouflages/solidColors.js
+++ b/src/data/requirements/camouflages/solidColors.js
@@ -67,7 +67,7 @@ export default {
 		weapon: 'Bryson 800',
 		level: '20',
 		challenge: {
-			amount: 25,
+			amount: 20,
 			type: 'one_shot',
 		},
 	},


### PR DESCRIPTION
Bryson 800 only requires 20 one shot kills, not 25.